### PR TITLE
Add `precision` and `temp_step` to autodiscovery config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 #
 
 PROJECT_NAME := esp32_mqtt_eq3
-PROJECT_VER := 1.70
+PROJECT_VER := 1.71
 
 COMPONENT_ADD_INCLUDEDIRS := components/include
 

--- a/README.md
+++ b/README.md
@@ -284,3 +284,13 @@ menuconfig options allow setting of some parameters at compile time.
 - The boot-mode GPIO pin (normally a button on GPIO 0 on many ESP32 platforms) used to force the device into AP mode at boot.
 - Status LED GPIO which indicates if the device is in AP mode.
 - Password for AP mode (enables WPA2PSK) to prevent unwanted access should the device go into AP mode when it is unable to connect to its configured Access Point.
+
+To compile this application, you need to
+1. Install ESP-IDF (e.g. via VSCode plugin)
+2. go to the IDF directory (e.g. `$HOME/esp/esp-idf`)
+3. `git checkout v4.4.3`
+4. Run `install.sh` (if this fails, you may need to install Python3.8 and add it explicitly to the search script at `$HOME/esp/esp-idf/tools/detect_python.sh` and delete any previous venv)
+5. Go to your project directory, activate the IDF using `. $HOME/esp/esp-idf/export.sh`
+6. Run `idf.py build`
+
+When flashing after compilation, please note that the resulting files are located at `build/ota_data_initial.bin`, `build/bootloader/bootloader.bin`, `build/esp32_mqtt_eq3.bin` and `build/partition_table/partition-table.bin`.

--- a/main/eq3_ha_discovery.c
+++ b/main/eq3_ha_discovery.c
@@ -58,6 +58,10 @@ cJSON* generate_ha_therm_payload (char mac[6]) {
     cJSON_AddNumberToObject (root, "max_temp", 29.5);
     // "min_temp": 5
     cJSON_AddNumberToObject (root, "min_temp", 5);
+    // "precision": 0.5
+    cJSON_AddNumberToObject (root, "precision", 0.5);
+    // "temp_step": 0.5
+    cJSON_AddNumberToObject (root, "temp_step", 0.5);
     // "temperature_unit": "C"
     cJSON_AddStringToObject (root, "temperature_unit", "C");
     // "mode_command_topic": "eq3_radin/trv/XX:XX:XX:YY:YY:YY/mode"


### PR DESCRIPTION
HomeAssistant has a default `precision` of `0.1` and a default `temp_step` of `1`, which affects setpoint setting such that you can only push full-degree temperatures to the thermostat.
With this PR, both values are set to the thermostat-supported value of `0.5`. I've tested with my HomeAssistant that after this fix, you can also set e.g. `20.5 °C` via the UI.

I've also added instructions on how to compile this project because it wasn't straightforward to me as an IDF newbie.